### PR TITLE
Bump chatgpt dependency to 3.3.6 (latest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "npx tsc"
   },
   "dependencies": {
-    "chatgpt": "^3.3.1",
+    "chatgpt": "^3.3.5",
     "dotenv": "^14.2.0",
     "matrix-bot-sdk": "^0.6.2",
     "puppeteer": "^19.4.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "npx tsc"
   },
   "dependencies": {
-    "chatgpt": "^3.3.5",
+    "chatgpt": "^3.3.6",
     "dotenv": "^14.2.0",
     "matrix-bot-sdk": "^0.6.2",
     "puppeteer": "^19.4.1",


### PR DESCRIPTION
This might fix some authentication issues people are having. See: https://github.com/transitive-bullshit/chatgpt-api/releases (we were previously using 3.3.1)